### PR TITLE
clean also the post pulse test table when loading a new pulse setting

### DIFF
--- a/pppat/ui/mainwindow.py
+++ b/pppat/ui/mainwindow.py
@@ -309,6 +309,8 @@ class MainWindow(QMainWindow):
         """ Load the pulse settings when user clicks on 'load' """
         # clean the pre pulse test result table
         self.clean_table_pre_test()
+        # clean the post pulse test result table
+        self.clean_table_post_test()
 
         # construct the pulse settings
         self.pulse_settings = PulseSettings()


### PR DESCRIPTION
such avoid leaving the table filled, in order to incite the eic to redo the post pulse tests