### PR TITLE
Correct bug related to Top Heating Security Flags

### DIFF
--- a/pppat/libpulse/utils.py
+++ b/pppat/libpulse/utils.py
@@ -11,6 +11,8 @@ from pppat.libpulse.check_result import CheckResult as Result
 from pppat.libpulse.utils_west import is_online
 from pywed import PyWEDException, tsmat
 
+from sys import exc_info  # for debug
+import linecache  # for debug 
 import logging  # pour ajouter des informations au log de PPPPAT
 logger = logging.getLogger(__name__)
 
@@ -98,6 +100,16 @@ def pre_pulse_test(test_func):
                 # problem with manipulating the data (our fault!)
                 test = Result(text = str(e), code = Result.BROKEN)
                 logger.error(str(e))
+                # Adding additional information concerning the problem
+                exc_type, exc_obj, tb = exc_info()
+                f = tb.tb_frame
+                lineno = tb.tb_lineno
+                filename = f.f_code.co_filename
+                linecache.checkcache(filename)
+                line = linecache.getline(filename, lineno, f.f_globals)
+                debug_msg = f'EXCEPTION IN ({filename}, LINE {lineno} "{line.strip()}"): {exc_obj}'
+                logger.error(debug_msg)
+                
             except PyWEDException as e:
                 # problem to get the data from database (not our fault!)
                 test = Result(text = str(e), code = Result.UNAVAILABLE)

--- a/pppat/ui/console.py
+++ b/pppat/ui/console.py
@@ -13,21 +13,27 @@ class ConsoleWidget(RichJupyterWidget):
     """Jupyter kernel client in Qt"""
 
     def __init__(self, *args, **kwargs):
-        super(ConsoleWidget, self).__init__(*args, **kwargs)
+        super().__init__()
 
-        self.kernel_manager = QtKernelManager(kernel_name=USE_KERNEL)
-        self.kernel_manager.start_kernel()
+        kernel_manager = QtKernelManager(kernel_name=USE_KERNEL)
+        kernel_manager.start_kernel()
+    
+        kernel_client = kernel_manager.client()
+        kernel_client.start_channels()
 
-        self.kernel_client = self.kernel_manager.client()
-        self.kernel_client.start_channels()
+        self.kernel_manager = kernel_manager
+        self.kernel_client = kernel_client
 
         self.exit_requested.connect(self.stop)
 
         self.font_size = 8
+        # setup scientific mode and import WEST database access module
         self.execute_command('%pylab')
         self.execute_command('import pywed as pd')
-        
+        self.execute_command('from pywed import *')
+
     def stop(self):
+        print('Shutting down kernel...')
         self.kernel_client.stop_channels()
         self.kernel_manager.shutdown_kernel()
 
@@ -43,8 +49,6 @@ class ConsoleWidget(RichJupyterWidget):
         Clears the terminal
         """
         self._control.clear()
-
-        # self.kernel_manager
 
     def print_text(self, text):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,8 @@ numpy
 pyqtgraph
 pywed
 IRFMtb
-tornado>=4.5.3
-jupyter_client>=5.2.2
+tornado
+jupyter_client
 pandas
+linecache
 


### PR DESCRIPTION
This bug appeared since pulse #55546, where a new security flag concerning IR modulation filtering bandwidth has been added to the Top flags 'DPCS;HEATING_PARA;HEATING_SECU'